### PR TITLE
Handle nil case for scheduled arrivals

### DIFF
--- a/MMM-CTA.js
+++ b/MMM-CTA.js
@@ -95,6 +95,12 @@ Module.register('MMM-CTA', {
     const diffInMilliseconds = new Date(arrivalTime) - now;
     const diffInMinutes = Math.floor(diffInMilliseconds / 1000 / 60);
 
-    return diffInMinutes === 0 ? 'DUE' : diffInMinutes.toString();
+    if (diffInMinutes === 0) {
+      return 'DUE'
+    } else if (diffInMinutes === 1) {
+      return diffInMinutes.toString() + ' min'
+    } else {
+      return diffInMinutes.toString() + ' mins'
+    }
   },
 });

--- a/templates/MMM-CTA.njk
+++ b/templates/MMM-CTA.njk
@@ -26,39 +26,43 @@
             {% if routeIcons %}
               <th class="align-left"></th>
             {% endif %}
+            {% if stop.arrivals[0].arrival %}
+              <th class="align-left">
+                {{ "DIRECTION" | translate }}
+              </th>
 
-            <th class="align-left">
-              {{ "DIRECTION" | translate }}
-            </th>
-
-            <th class="align-right">
-              {{ "ARRIVAL" | translate }}
-            </th>
+              <th class="align-right">
+                {{ "ARRIVAL" | translate }}
+              </th>
+            {% endif %}
           </tr>
         </thead>
-
         <tbody>
-          {% for arrival in stop.arrivals %}
-            <tr class="small">
-              {% if routeIcons %}
-                <td class="icon-col align-left {{ arrival.routeColor }}">
-                  {% if stop.type === 'train' %}
-                    <i class="fa fa-train fa-sm cta-mr-5"></i>
-                  {% elif stop.type === 'bus' %}
-                    <i class="fa fa-bus fa-sm cta-mr-5"></i>
-                  {% endif %}
+	  {% if stop.arrivals[0].arrival %}
+            {% for arrival in stop.arrivals %}
+              <tr class="small">
+                {% if routeIcons %}
+                  <td class="icon-col align-left {{ arrival.routeColor }}">
+                    {% if stop.type === 'train' %}
+                      <i class="fa fa-train fa-sm cta-mr-5"></i>
+                    {% elif stop.type === 'bus' %}
+                      <i class="fa fa-bus fa-sm cta-mr-5"></i>
+                    {% endif %}
+                  </td>
+                {% endif %}
+
+                <td class="align-left">
+                  {{ arrival.direction }}
                 </td>
-              {% endif %}
 
-              <td class="align-left">
-                {{ arrival.direction }}
-              </td>
-
-              <td class="bright align-right bold">
-                {{ arrival.arrival }}
-              </td>
-            </tr>
-          {% endfor %}
+                <td class="bright align-right">
+                  {{ arrival.arrival }}
+                </td>
+              </tr>
+            {% endfor %}
+	  {% else %}
+	    <td class="small">No planned arrivals.</td>
+	  {% endif %}
         </tbody>
       </table>
     {% endfor %}

--- a/templates/MMM-CTA.njk
+++ b/templates/MMM-CTA.njk
@@ -38,7 +38,7 @@
           </tr>
         </thead>
         <tbody>
-	  {% if stop.arrivals[0].arrival %}
+	        {% if stop.arrivals[0].arrival %}
             {% for arrival in stop.arrivals %}
               <tr class="small">
                 {% if routeIcons %}
@@ -60,9 +60,9 @@
                 </td>
               </tr>
             {% endfor %}
-	  {% else %}
-	    <td class="small">No planned arrivals.</td>
-	  {% endif %}
+	        {% else %}
+	          <td class="small">No planned arrivals.</td>
+	        {% endif %}
         </tbody>
       </table>
     {% endfor %}


### PR DESCRIPTION
Hey Jordan! Love the updates to Nate's module. I was experiencing some issues with the other module since updating my Node version earlier today. Due to these issues, I was worried I'd have to take it off my mirror until I found yours, so thank you for the updates.

As for the reason for this PR, I frequent a bus stop that runs only on weekdays during work hours, so a good amount of time my mirror would show no options for bus ETAs (shown below). 
![image](https://github.com/JHWelch/MMM-CTA/assets/26585685/c865a255-2257-46bc-a45a-c2a0edfbdc42)

Therefore, I added handling for this case which removes the `Direction/Arrival` headings and adds a note to the user that there are no planned arrivals.

Additionally, I added a suffix of `min` or `mins` respectively to the arrival times. This isn't a huge deal to me but I figured why not. Feel free to take whatever you want from here or nothing at all. Thanks again!
![image](https://github.com/JHWelch/MMM-CTA/assets/26585685/df7d57b5-fd94-483b-8ef8-9b74d7817f5f)

Side note, I also noticed that the table re-renders each time an update interval is reached causing a momentary stutter in the display but that is a fix for another day