### PR TITLE
Add ability to style suffix

### DIFF
--- a/MMM-CTA.js
+++ b/MMM-CTA.js
@@ -15,6 +15,7 @@ Module.register('MMM-CTA', {
     maxResultsBus: 5,
     maxResultsTrain: 5,
     routeIcons: true,
+    suffixStyle: 'long',
     stops: [],
   },
 
@@ -109,10 +110,22 @@ Module.register('MMM-CTA', {
     if (minutesInt === 0) {
       return 'DUE';
     }
-    if (minutesInt === 1) {
-      return `${minutesInt.toString()} min`;
-    }
+    return this.minutesWithSuffix(minutesInt);
+  },
 
-    return `${minutesInt.toString()} mins`;
+  minutesWithSuffix(minutes) {
+    switch (this.config.suffixStyle) {
+      case 'none':
+        return minutes.toString();
+      case 'short':
+        return `${minutes.toString()}m`;
+      case 'long':
+      default:
+        if (minutes === 1) {
+          return `${minutes.toString()} min`;
+        }
+
+        return `${minutes.toString()} mins`;
+    }
   },
 });

--- a/README.md
+++ b/README.md
@@ -46,19 +46,20 @@ var config = {
 
 ## Configuration options
 
-| Option            | Required?    | Description                                                            |
-| ----------------- | ------------ | ---------------------------------------------------------------------- |
-| `busApiKey`       | **Required** | See [Obtaining CTA API keys](#obtaining-cta-api-keys)                  |
-| `trainApiKey`     | **Required** | See [Obtaining CTA API keys](#obtaining-cta-api-keys)                  |
-| `stops`           | **Required** | Array of stops to display. See [`stops` option](#stops-option)         |
-| `updateInterval`  | *Optional*   | Refresh time in milliseconds <br>Default 60000 milliseconds (1 minute) |
-| `maxResultsBus`   | *Optional*   | Maximum number of bus results to display <br>Default `5`               |
-| `maxResultsTrain` | *Optional*   | Maximum number of train results to display <br>Default `5`             |
-| `routeIcons`      | *Optional*   | True/False - Display icons next to routes. <br>Default `true`          |
+| Option            | Required?    | Description                                                                         |
+| ----------------- | ------------ | ----------------------------------------------------------------------------------- |
+| `busApiKey`       | **Required** | See [Obtaining CTA API keys](#obtaining-cta-api-keys)                               |
+| `trainApiKey`     | **Required** | See [Obtaining CTA API keys](#obtaining-cta-api-keys)                               |
+| `stops`           | **Required** | Array of stops to display. See [`stops` option](#stops-option)                      |
+| `updateInterval`  | *Optional*   | Refresh time in milliseconds <br>Default 60000 milliseconds (1 minute)              |
+| `maxResultsBus`   | *Optional*   | Maximum number of bus results to display <br>Default `5`                            |
+| `maxResultsTrain` | *Optional*   | Maximum number of train results to display <br>Default `5`                          |
+| `routeIcons`      | *Optional*   | True/False - Display icons next to routes. <br>Default `true`                       |
+| `suffixStyle`     | *Optional*   | Style of suffix for the arrival time. `long`, `short`, or `none` <br>Default `long` |
 
 ### `stops` option
 
-The `stops` option is an array of objects. Each object represents a stop to display. 
+The `stops` option is an array of objects. Each object represents a stop to display.
 
 ```js
 {

--- a/__tests__/MMM-CTA.spec.js
+++ b/__tests__/MMM-CTA.spec.js
@@ -24,6 +24,7 @@ it('has a default config', () => {
     maxResultsTrain: 5,
     maxResultsBus: 5,
     routeIcons: true,
+    suffixStyle: 'long',
     stops: [],
   });
 });
@@ -278,6 +279,46 @@ describe('socketNotificationReceived', () => {
       MMMCTA.socketNotificationReceived('NOT-MMM-CTA-DATA', payload);
 
       expect(MMMCTA.data.stops).toEqual(undefined);
+    });
+  });
+});
+
+describe('minutesWithSuffix', () => {
+  describe('suffix style is long', () => {
+    beforeEach(() => {
+      MMMCTA.setConfig({ suffixStyle: 'long' });
+    });
+
+    it('returns min for singular', () => {
+      expect(MMMCTA.minutesWithSuffix(1)).toBe('1 min');
+    });
+
+    it('returns mins for plural', () => {
+      expect(MMMCTA.minutesWithSuffix(2)).toBe('2 mins');
+    });
+  });
+
+  describe('suffix style is short', () => {
+    beforeEach(() => {
+      MMMCTA.setConfig({ suffixStyle: 'short' });
+    });
+
+    it('returns m for singular', () => {
+      expect(MMMCTA.minutesWithSuffix(1)).toBe('1m');
+    });
+
+    it('returns m for plural', () => {
+      expect(MMMCTA.minutesWithSuffix(2)).toBe('2m');
+    });
+  });
+
+  describe('suffix style is none', () => {
+    beforeEach(() => {
+      MMMCTA.setConfig({ suffixStyle: 'none' });
+    });
+
+    it('returns number', () => {
+      expect(MMMCTA.minutesWithSuffix(1)).toBe('1');
     });
   });
 });


### PR DESCRIPTION
<!-- 
Thanks for Opening a Pull Request! 

I appreciate your time and effort to contribute to this project.

Please complete the TODO items below and provide as much information as needed to help me understand your changes.

If you would like collaboration feel free to open a draft & ask for help or feedback.
-->

## Description
Adds new config option for customizing the prefix after the minutes until arrival

* `"long"` (default) is current: `1 min`/`10 mins` 
* `"short"`: `1m`/`10m`
* `"none"`: `1`/`10`

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/JHWelch/MMM-CTA/blob/main/CONTRIBUTING) document
- [X] I have updated the documentation as needed
- [X] I have added/updated tests to cover my changes
