### PR TITLE
Add ability to hide headers

### DIFF
--- a/MMM-CTA.js
+++ b/MMM-CTA.js
@@ -16,6 +16,7 @@ Module.register('MMM-CTA', {
     maxResultsTrain: 5,
     routeIcons: true,
     suffixStyle: 'long',
+    showHeaders: true,
     stops: [],
   },
 
@@ -52,6 +53,7 @@ Module.register('MMM-CTA', {
     return {
       loading: this.loading,
       routeIcons: this.config.routeIcons,
+      showHeaders: this.config.showHeaders,
       stops: this.data.stops?.map((stop) => ({
         ...stop,
         arrivals: stop.arrivals?.map((arrival) => ({

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ var config = {
 | `maxResultsBus`   | *Optional*   | Maximum number of bus results to display <br>Default `5`                            |
 | `maxResultsTrain` | *Optional*   | Maximum number of train results to display <br>Default `5`                          |
 | `routeIcons`      | *Optional*   | True/False - Display icons next to routes. <br>Default `true`                       |
+| `showHeaders`     | *Optional*   | True/False - Display headers for each stop. <br>Default `true`                      |
 | `suffixStyle`     | *Optional*   | Style of suffix for the arrival time. `long`, `short`, or `none` <br>Default `long` |
 
 ### `stops` option

--- a/__tests__/MMM-CTA.spec.js
+++ b/__tests__/MMM-CTA.spec.js
@@ -25,6 +25,7 @@ it('has a default config', () => {
     maxResultsBus: 5,
     routeIcons: true,
     suffixStyle: 'long',
+    showHeaders: true,
     stops: [],
   });
 });
@@ -127,6 +128,7 @@ describe('getTemplateData', () => {
       expect(MMMCTA.getTemplateData()).toEqual({
         loading: MMMCTA.loading,
         routeIcons: MMMCTA.config.routeIcons,
+        showHeaders: MMMCTA.config.showHeaders,
         stops: [{
           type: 'bus',
           name: 'Mock Stop',
@@ -158,6 +160,16 @@ describe('getTemplateData', () => {
 
       it('returns routeIcons false', () => {
         expect(MMMCTA.getTemplateData().routeIcons).toEqual(false);
+      });
+    });
+
+    describe('showHeaders turned off', () => {
+      beforeEach(() => {
+        MMMCTA.setConfig({ showHeaders: false });
+      });
+
+      it('returns showHeaders false', () => {
+        expect(MMMCTA.getTemplateData().showHeaders).toEqual(false);
       });
     });
   });
@@ -200,6 +212,7 @@ describe('getTemplateData', () => {
       expect(MMMCTA.getTemplateData()).toEqual({
         loading: MMMCTA.loading,
         routeIcons: MMMCTA.config.routeIcons,
+        showHeaders: MMMCTA.config.showHeaders,
         stops: [{
           type: 'train',
           name: 'Mock Stop',

--- a/__tests__/templates/MMM-CTA.njk.spec.js
+++ b/__tests__/templates/MMM-CTA.njk.spec.js
@@ -135,6 +135,40 @@ describe('bus stop', () => {
       expect(template).not.toContain('fa-bus');
     });
   });
+
+  describe('showHeaders turned on', () => {
+    beforeEach(() => {
+      data.showHeaders = true;
+      template = nunjucks.render('MMM-CTA.njk', data);
+      data.stops = [{
+        type: 'bus',
+        name: 'Bus Stop',
+        arrivals: [
+          {
+            direction: 'North',
+            arrival: 5,
+          },
+        ],
+      }];
+    });
+
+    it('shows headers', () => {
+      expect(template).toContain('DIRECTION');
+      expect(template).toContain('ARRIVAL');
+    });
+  });
+
+  describe('showHeaders turned off', () => {
+    beforeEach(() => {
+      data.showHeaders = false;
+      template = nunjucks.render('MMM-CTA.njk', data);
+    });
+
+    it('does not show headers', () => {
+      expect(template).not.toContain('DIRECTION');
+      expect(template).not.toContain('ARRIVAL');
+    });
+  });
 });
 
 describe('multiple stops', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-cta",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Magic Mirror Module for displaying CTA Train and Bus arrival times",
   "main": "MMM-CTA.js",
   "scripts": {

--- a/templates/MMM-CTA.njk
+++ b/templates/MMM-CTA.njk
@@ -22,20 +22,22 @@
             </td>
           </tr>
 
-          <tr class="small">
-            {% if stop.arrivals.length %}
-              {% if routeIcons %}
-                <th class="align-left"></th>
-              {% endif %}
-              <th class="align-left">
-                {{ "DIRECTION" | translate }}
-              </th>
+          {% if showHeaders %}
+            <tr class="small">
+              {% if stop.arrivals.length %}
+                {% if routeIcons %}
+                  <th class="align-left"></th>
+                {% endif %}
+                <th class="align-left">
+                  {{ "DIRECTION" | translate }}
+                </th>
 
-              <th class="align-right">
-                {{ "ARRIVAL" | translate }}
-              </th>
-            {% endif %}
-          </tr>
+                <th class="align-right">
+                  {{ "ARRIVAL" | translate }}
+                </th>
+              {% endif %}
+            </tr>
+          {% endif %}
         </thead>
         <tbody>
 	        {% if stop.arrivals.length %}


### PR DESCRIPTION
Adds ability to hide headers from each stop's individual table.

```jsonc
{
  // ...
  config: {
    showHeaders: false,
  }
}
```

Defaults to `true` for backwards compatability.

![CleanShot 2024-05-26 at 15 24 00@2x](https://github.com/JHWelch/MMM-CTA/assets/4480375/b70b2692-8ca5-4f40-b5a3-959165368dcc)
