### PR TITLE
Add minimum arrival time option to stop config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,19 @@ The `stops` option is an array of objects. Each object represents a stop to disp
     {
       type: 'train',
       id: 41410,
-      name: 'Blue Line'
+      name: 'Blue Line',
+      minimumArrivalTime: 600000,
     }
   ]
 }
 ```
 
-| Property | Description                                                          |
-| -------- | -------------------------------------------------------------------- |
-| `type`   | Type of stop. Either `bus` or `train`                                |
-| `id`     | Stop ID. See [Finding Stop IDs](#finding-stop-ids)                   |
-| `name`   | Name of stop. This is displayed in the header of the stop's results. |
+| Property              | Description                                                                         |
+| --------              | ----------------------------------------------------------------------------------- |
+| `type`                | Type of stop. Either `bus` or `train`                                               |
+| `id`                  | Stop ID. See [Finding Stop IDs](#finding-stop-ids)                                  |
+| `name`                | Name of stop. This is displayed in the header of the stop's results.                |
+| `minimumArrivalTime`  | The minimum time to arrival for the bus or train to be displayed. In ms. Default 0. |
 
 ### Finding Stop IDs
 

--- a/__tests__/node_helper.spec.js
+++ b/__tests__/node_helper.spec.js
@@ -136,6 +136,7 @@ let fetch;
 beforeEach(() => {
   helper = require('../node_helper');
   helper.setName('MMM-CTA');
+  jest.useFakeTimers().setSystemTime(new Date('2024-01-20T21:27:00'));
 });
 
 describe('socketNotificationReceived', () => {
@@ -190,6 +191,41 @@ describe('socketNotificationReceived', () => {
         }],
       });
     });
+
+    describe('minimumArrivalTime is set', () => {
+      beforeEach(() => {
+        mockTrainFetch();
+  
+        helper.socketNotificationReceived('MMM-CTA-FETCH', {
+          trainApiKey: 'TRAIN_API_KEY',
+          busApiKey: null,
+          maxResultsTrain: 5,
+          maxResultsBus: 5,
+          stops: [{
+            type: 'train',
+            id: '1234',
+            name: 'Mock Stop',
+            minimumArrivalTime: 120000,
+          }],
+        });
+      });
+
+      it('sends data to client', () => {
+        expect(helper.sendSocketNotification).toHaveBeenCalledWith('MMM-CTA-DATA', {
+          stops: [{
+            type: 'train',
+            name: 'Mock Stop',
+            arrivals: [
+              {
+                direction: 'Howard',
+                time: new Date('2024-01-20T21:32:03'),
+                routeColor: 'green',
+              },
+            ],
+          }],
+        });
+      });
+    });
   });
 
   describe('passed proper bus config', () => {
@@ -233,6 +269,41 @@ describe('socketNotificationReceived', () => {
             },
           ],
         }],
+      });
+    });
+
+    describe('minimumArrivalTime is set', () => {
+      beforeEach(() => {
+        mockBusFetch(fetch);
+  
+        helper.socketNotificationReceived('MMM-CTA-FETCH', {
+          trainApiKey: null,
+          busApiKey: 'BUS_API_KEY',
+          maxResultsTrain: 5,
+          maxResultsBus: 5,
+          stops: [{
+            type: 'bus',
+            id: '1234',
+            name: 'Mock Stop',
+            minimumArrivalTime: 240000,
+          }],
+        });
+      });
+
+      it('sends data to client', () => {
+        expect(helper.sendSocketNotification).toHaveBeenCalledWith('MMM-CTA-DATA', {
+          stops: [{
+            type: 'bus',
+            name: 'Mock Stop',
+            arrivals: [
+              {
+                route: '152',
+                direction: 'Westbound',
+                arrival: '27',
+              },
+            ],
+          }],
+        });
       });
     });
   });

--- a/node_helper.js
+++ b/node_helper.js
@@ -36,6 +36,7 @@ module.exports = NodeHelper.create({
             stop.id,
             maxResultsTrain,
             trainApiKey,
+            stop.minimumArrivalTime ?? 0,
           ),
         };
       }
@@ -47,6 +48,7 @@ module.exports = NodeHelper.create({
           stop.id,
           maxResultsBus,
           busApiKey,
+          stop.minimumArrivalTime ?? 0,
         ),
       };
     }));
@@ -56,22 +58,25 @@ module.exports = NodeHelper.create({
     });
   },
 
-  async getBusData (id, maxResults, apiKey) {
+  async getBusData (id, maxResults, apiKey, minimumArrivalTime) {
     const response = await fetch(this.busUrl(id, maxResults, apiKey));
     const { 'bustime-response': data } = await response.json();
+    const minimumArrivalTimeMinutes = minimumArrivalTime / 1000 / 60;
 
     if (!data?.prd) {
       return [];
     }
 
-    return data.prd.map((bus) => ({
+    return data.prd.filter((bus) => {
+      return bus.prdctdn >= minimumArrivalTimeMinutes;
+    }).map((bus) => ({
       route: bus.rt,
       direction: bus.rtdir,
       arrival: bus.prdctdn,
     }));
   },
 
-  async getTrainData (id, maxResults, apiKey) {
+  async getTrainData (id, maxResults, apiKey, minimumArrivalTime) {
     const response = await fetch(this.trainUrl(id, maxResults, apiKey));
     const { ctatt: data } = await response.json();
 
@@ -79,7 +84,10 @@ module.exports = NodeHelper.create({
       return [];
     }
 
-    return data.eta.map((train) => ({
+    return data.eta.filter((train) => {
+      const arrivalTime = new Date(train.arrT);
+      return arrivalTime - Date.now() > minimumArrivalTime;
+    }).map((train) => ({
       direction: train.destNm,
       routeColor: this.routeToColor(train.rt),
       time: new Date(train.arrT),

--- a/node_helper.js
+++ b/node_helper.js
@@ -86,6 +86,7 @@ module.exports = NodeHelper.create({
 
     return data.eta.filter((train) => {
       const arrivalTime = new Date(train.arrT);
+
       return arrivalTime - Date.now() > minimumArrivalTime;
     }).map((train) => ({
       direction: train.destNm,


### PR DESCRIPTION
<!-- 
Thanks for Opening a Pull Request! 

I appreciate your time and effort to contribute to this project.

Please complete the TODO items below and provide as much information as needed to help me understand your changes.

If you would like collaboration feel free to open a draft & ask for help or feedback.
-->

## Description

Allow setting a `minimumArrivalTime` value on stop configs, which will filter train and bus arrivals that occur within that minimum time. This is helpful for me personally, as the location of my MagicMirror instance is about a 10 minute walk from the CTA station, so I don't need to clutter the arrival list with trains that I won't be able to catch.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JHWelch/MMM-CTA/blob/main/CONTRIBUTING) document
- [x] I have updated the documentation as needed
- [x] I have added/updated tests to cover my changes

## Notes for Reviewers
