### PR TITLE
Show headers per stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The `stops` option is an array of objects. Each object represents a stop to disp
 | `id`                 | **Required** | Stop ID. See [Finding Stop IDs](#finding-stop-ids)                                  |
 | `name`               | **Required** | Name of stop. This is displayed in the header of the stop's results.                |
 | `minimumArrivalTime` | *Optional*   | The minimum time to arrival for the bus or train to be displayed. In ms. Default 0. |
+| `showHeaders`        | *Optional*   | Override global `showHeaders` option for this stop only. <br>Default: global value. |
 
 ### Finding Stop IDs
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `stops` option is an array of objects. Each object represents a stop to disp
 | -------------------- | ------------ | ----------------------------------------------------------------------------------- |
 | `type`               | **Required** | Type of stop. Either `bus` or `train`                                               |
 | `id`                 | **Required** | Stop ID. See [Finding Stop IDs](#finding-stop-ids)                                  |
-| `name`               | **Required** | Name of stop. This is displayed in the header of the stop's results.                |
+| `name`               | *Optional*   | Name of stop. This is displayed in the header of the stop's results.                |
 | `minimumArrivalTime` | *Optional*   | The minimum time to arrival for the bus or train to be displayed. In ms. Default 0. |
 | `showHeaders`        | *Optional*   | Override global `showHeaders` option for this stop only. <br>Default: global value. |
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ The `stops` option is an array of objects. Each object represents a stop to disp
 }
 ```
 
-| Property              | Description                                                                         |
-| --------              | ----------------------------------------------------------------------------------- |
-| `type`                | Type of stop. Either `bus` or `train`                                               |
-| `id`                  | Stop ID. See [Finding Stop IDs](#finding-stop-ids)                                  |
-| `name`                | Name of stop. This is displayed in the header of the stop's results.                |
-| `minimumArrivalTime`  | The minimum time to arrival for the bus or train to be displayed. In ms. Default 0. |
+| Property             | Required?    | Description                                                                         |
+| -------------------- | ------------ | ----------------------------------------------------------------------------------- |
+| `type`               | **Required** | Type of stop. Either `bus` or `train`                                               |
+| `id`                 | **Required** | Stop ID. See [Finding Stop IDs](#finding-stop-ids)                                  |
+| `name`               | **Required** | Name of stop. This is displayed in the header of the stop's results.                |
+| `minimumArrivalTime` | *Optional*   | The minimum time to arrival for the bus or train to be displayed. In ms. Default 0. |
 
 ### Finding Stop IDs
 

--- a/__tests__/node_helper.spec.js
+++ b/__tests__/node_helper.spec.js
@@ -267,6 +267,7 @@ describe('socketNotificationReceived', () => {
       it('sends data to client', () => {
         expect(helper.sendSocketNotification).toHaveBeenCalledWith('MMM-CTA-DATA', {
           stops: [{
+            id: '1234',
             type: 'train',
             name: 'Mock Stop',
             arrivals: [
@@ -323,8 +324,10 @@ describe('socketNotificationReceived', () => {
       it('sends data to client, filtered and still truncated', () => {
         expect(helper.sendSocketNotification).toHaveBeenCalledWith('MMM-CTA-DATA', {
           stops: [{
+            id: '1234',
             type: 'train',
             name: 'Mock Stop',
+            minimumArrivalTime: 120000,
             arrivals: [
               {
                 direction: 'Howard',
@@ -370,6 +373,7 @@ describe('socketNotificationReceived', () => {
       it('sends data to client', () => {
         expect(helper.sendSocketNotification).toHaveBeenCalledWith('MMM-CTA-DATA', {
           stops: [{
+            id: '1234',
             type: 'bus',
             name: 'Mock Stop',
             arrivals: [
@@ -426,8 +430,10 @@ describe('socketNotificationReceived', () => {
       it('sends data to client', () => {
         expect(helper.sendSocketNotification).toHaveBeenCalledWith('MMM-CTA-DATA', {
           stops: [{
+            id: '1234',
             type: 'bus',
             name: 'Mock Stop',
+            minimumArrivalTime: 240000,
             arrivals: [
               {
                 route: '152',
@@ -485,6 +491,7 @@ describe('socketNotificationReceived', () => {
       expect(helper.sendSocketNotification).toHaveBeenCalledWith('MMM-CTA-DATA', {
         stops: [
           {
+            id: '1234',
             type: 'train',
             name: 'Mock Stop',
             arrivals: [
@@ -511,6 +518,7 @@ describe('socketNotificationReceived', () => {
             ],
           },
           {
+            id: '1234',
             type: 'bus',
             name: 'Mock Stop',
             arrivals: [
@@ -561,6 +569,7 @@ describe('socketNotificationReceived', () => {
     it('sends data to client', () => {
       expect(helper.sendSocketNotification).toHaveBeenCalledWith('MMM-CTA-DATA', {
         stops: [{
+          id: '1234',
           type: 'bus',
           name: 'Mock Stop',
           arrivals: [],

--- a/__tests__/templates/MMM-CTA.njk.spec.js
+++ b/__tests__/templates/MMM-CTA.njk.spec.js
@@ -139,7 +139,6 @@ describe('bus stop', () => {
   describe('showHeaders turned on', () => {
     beforeEach(() => {
       data.showHeaders = true;
-      template = nunjucks.render('MMM-CTA.njk', data);
       data.stops = [{
         type: 'bus',
         name: 'Bus Stop',
@@ -153,20 +152,38 @@ describe('bus stop', () => {
     });
 
     it('shows headers', () => {
+      template = nunjucks.render('MMM-CTA.njk', data);
+
       expect(template).toContain('DIRECTION');
       expect(template).toContain('ARRIVAL');
+    });
+
+    it('can be overridden per stop', () => {
+      data.stops[0].showHeaders = false;
+      template = nunjucks.render('MMM-CTA.njk', data);
+
+      expect(template).not.toContain('DIRECTION');
+      expect(template).not.toContain('ARRIVAL');
     });
   });
 
   describe('showHeaders turned off', () => {
     beforeEach(() => {
       data.showHeaders = false;
-      template = nunjucks.render('MMM-CTA.njk', data);
     });
 
     it('does not show headers', () => {
+      template = nunjucks.render('MMM-CTA.njk', data);
       expect(template).not.toContain('DIRECTION');
       expect(template).not.toContain('ARRIVAL');
+    });
+
+    it('can be overridden per stop', () => {
+      data.stops[0].showHeaders = true;
+      template = nunjucks.render('MMM-CTA.njk', data);
+
+      expect(template).toContain('DIRECTION');
+      expect(template).toContain('ARRIVAL');
     });
   });
 });

--- a/__tests__/templates/MMM-CTA.njk.spec.js
+++ b/__tests__/templates/MMM-CTA.njk.spec.js
@@ -42,6 +42,14 @@ describe('train stop', () => {
     expect(template).toContain('Train Stop');
   });
 
+  it('will not show name section if not included', () => {
+    data.stops[0].name = null;
+    template = nunjucks.render('MMM-CTA.njk', data);
+
+    expect(template).not.toContain('Train Stop');
+    expect(template).not.toContain('class="bright align-middle"');
+  });
+
   it('shows train stop directions', () => {
     template = nunjucks.render('MMM-CTA.njk', data);
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -30,8 +30,7 @@ module.exports = NodeHelper.create({
     const responses = await Promise.all(stops.map(async (stop) => {
       if (stop.type === 'train') {
         return {
-          type: 'train',
-          name: stop.name,
+          ...stop,
           arrivals: await this.getTrainData(
             stop.id,
             maxResultsTrain,
@@ -42,8 +41,7 @@ module.exports = NodeHelper.create({
       }
 
       return {
-        type: 'bus',
-        name: stop.name,
+        ...stop,
         arrivals: await this.getBusData(
           stop.id,
           maxResultsBus,

--- a/node_helper.js
+++ b/node_helper.js
@@ -28,26 +28,23 @@ module.exports = NodeHelper.create({
     stops,
   }) {
     const responses = await Promise.all(stops.map(async (stop) => {
-      if (stop.type === 'train') {
-        return {
-          ...stop,
-          arrivals: await this.getTrainData(
-            stop.id,
-            maxResultsTrain,
-            trainApiKey,
-            stop.minimumArrivalTime ?? 0,
-          ),
-        };
-      }
-
-      return {
-        ...stop,
-        arrivals: await this.getBusData(
+      const arrivals = stop.type === 'train'
+        ? await this.getTrainData(
+          stop.id,
+          maxResultsTrain,
+          trainApiKey,
+          stop.minimumArrivalTime ?? 0,
+        )
+        : await this.getBusData(
           stop.id,
           maxResultsBus,
           busApiKey,
           stop.minimumArrivalTime ?? 0,
-        ),
+        );
+
+      return {
+        ...stop,
+        arrivals,
       };
     }));
 

--- a/templates/MMM-CTA.njk
+++ b/templates/MMM-CTA.njk
@@ -22,7 +22,7 @@
             </td>
           </tr>
 
-          {% if showHeaders %}
+          {% if stop.showHeaders === undefined and showHeaders or stop.showHeaders %}
             <tr class="small">
               {% if stop.arrivals.length %}
                 {% if routeIcons %}

--- a/templates/MMM-CTA.njk
+++ b/templates/MMM-CTA.njk
@@ -9,18 +9,20 @@
         <table class="cta-mt-10">
       {% endif %}
         <thead>
-          <tr>
-            <td
-              class="bright align-middle"
-              {% if routeIcons %}
-                colspan="3"
-              {% else %}
-                colspan="2"
-              {% endif %}
-            >
-              {{ stop.name}}
-            </td>
-          </tr>
+          {% if stop.name %}
+            <tr>
+              <td
+                class="bright align-middle"
+                {% if routeIcons %}
+                  colspan="3"
+                {% else %}
+                  colspan="2"
+                {% endif %}
+              >
+                {{ stop.name}}
+              </td>
+            </tr>
+          {% endif %}
 
           {% if stop.showHeaders === undefined and showHeaders or stop.showHeaders %}
             <tr class="small">


### PR DESCRIPTION
<!-- 
Thanks for Opening a Pull Request! 

I appreciate your time and effort to contribute to this project.

Please complete the TODO items below and provide as much information as needed to help me understand your changes.

If you would like collaboration feel free to open a draft & ask for help or feedback.
-->

## Description

Fixes #48 

Adds the ability to override `showHeaders` per stop.

Did this in a way that it should be easy to pass _other_ config values back with stops, in case we want to add anything else to overrides in the future.
